### PR TITLE
Refactored utils.parallel_map to work without Pool if processors is set to 1

### DIFF
--- a/nolitsa/utils.py
+++ b/nolitsa/utils.py
@@ -215,7 +215,7 @@ def parallel_map(func, values, args=tuple(), kwargs=dict(),
     """
     # True single core processing, in order to allow the func to be executed in
     # a Pool in a calling script.
-    if processes is not None and not processes:
+    if processes == 1:
         return np.asarray([func(value, *args, **kwargs) for value in values])
 
     from multiprocessing import Pool

--- a/nolitsa/utils.py
+++ b/nolitsa/utils.py
@@ -213,6 +213,11 @@ def parallel_map(func, values, args=tuple(), kwargs=dict(),
     results : array
         Output after applying func on each element in values.
     """
+    # True single core processing, in order to allow the func to be executed in
+    # a Pool in a calling script.
+    if processes is not None and not processes:
+        return np.asarray([func(value, *args, **kwargs) for value in values])
+
     from multiprocessing import Pool
 
     pool = Pool(processes=processes)


### PR DESCRIPTION
If functions are called from within a Pool in a parent script, the parent script will fail because it is unable to create new Process instances in a daemonized environment. By returning early without using the Pool in utils.parallel_map, this is averted.

Love the library btw, very well done